### PR TITLE
Add updated url crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Gilman Tolle <gilman.tolle@gmail.com>"]
 
 [dependencies]
 
-url = "0.2"
+url = "0.5"
 rustc-serialize = "0.3"
 
 [dependencies.hyper]


### PR DESCRIPTION
This wouldn't build for me in conjunction with some other crates, which use an updated version of the url crate. Updated the version to 0.5 in Cargo.toml and it worked.